### PR TITLE
Swap variables using deconstruction

### DIFF
--- a/src/LinearAssignment/ShortestPathSolver.cs
+++ b/src/LinearAssignment/ShortestPathSolver.cs
@@ -127,9 +127,7 @@ namespace LinearAssignment
                 {
                     var ip = path[j];
                     y[j] = ip;
-                    var tmp = j;
-                    j = x[ip];
-                    x[ip] = tmp;
+                    (j, x[ip]) = (x[ip], j);
                     if (ip == curRow)
                         break;
                 }
@@ -450,9 +448,7 @@ namespace LinearAssignment
             {
                 var i = lab[j];
                 y[j] = i;
-                var k = j;
-                j = x[i];
-                x[i] = k;
+                (j, x[i]) = (x[i], j);
                 if (i == i0)
                     return;
             }

--- a/src/LinearAssignment/SparseMatrixDouble.cs
+++ b/src/LinearAssignment/SparseMatrixDouble.cs
@@ -82,9 +82,7 @@ namespace LinearAssignment
 
             for (int i = 0, last = 0; i < NumColumns + 1; i++)
             {
-                var tmp = newIA[i];
-                newIA[i] = last;
-                last = tmp;
+                (newIA[i], last) = (last, newIA[i]);
             }
 
             return new SparseMatrixDouble(newA.ToList(), newIA.ToList(), newCA.ToList(), NumRows);

--- a/src/LinearAssignment/SparseMatrixInt.cs
+++ b/src/LinearAssignment/SparseMatrixInt.cs
@@ -77,9 +77,7 @@ namespace LinearAssignment
 
             for (int i = 0, last = 0; i < NumColumns + 1; i++)
             {
-                var tmp = newIA[i];
-                newIA[i] = last;
-                last = tmp;
+                (newIA[i], last) = (last, newIA[i]);
             }
 
             return new SparseMatrixInt(newA.ToList(), newIA.ToList(), newCA.ToList(), NumRows);


### PR DESCRIPTION
This pull request simply replaces classical value swaps (three lines + temporary variable) to a one line version using deconstruction. This is arguably more readable and [compiles to equivalent code](https://tearth.dev/posts/performance-of-the-different-ways-to-swap-two-values/).